### PR TITLE
Use ESP_ERROR_CHECK for SPI transmissions

### DIFF
--- a/main/drivers/display_driver.c
+++ b/main/drivers/display_driver.c
@@ -51,7 +51,7 @@ static void st7262_send_cmd(uint8_t cmd)
     t.user = (void*)0; // D/C = 0 pour commande
     
     ret = spi_device_polling_transmit(spi_handle, &t);
-    assert(ret == ESP_OK);
+    ESP_ERROR_CHECK(ret);
 }
 
 /**
@@ -72,7 +72,7 @@ static void st7262_send_data(const uint8_t *data, int len)
     t.user = (void*)1; // D/C = 1 pour données
     
     ret = spi_device_polling_transmit(spi_handle, &t);
-    assert(ret == ESP_OK);
+    ESP_ERROR_CHECK(ret);
 }
 
 /**


### PR DESCRIPTION
## Summary
- replace assertion checks with `ESP_ERROR_CHECK` in ST7262 command and data transmission helpers

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install espressif-idf` *(fails: No matching distribution found)*
- `pip install esp-idf` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68b834d4bed48323a719c52d1d5c415a