### PR TITLE
refactor: centralize LVGL style definitions

### DIFF
--- a/main/ui/ui_content.c
+++ b/main/ui/ui_content.c
@@ -249,14 +249,7 @@ static lv_obj_t* create_terrariums_screen(lv_obj_t *parent)
         lv_obj_t *status_indicator = lv_obj_create(terrarium_card);
         lv_obj_set_size(status_indicator, 60, 25);
         lv_obj_set_pos(status_indicator, 210, 35);
-        
-        static lv_style_t status_style;
-        lv_style_init(&status_style);
-        lv_style_set_bg_color(&status_style, COLOR_ACCENT_GREEN);
-        lv_style_set_bg_opa(&status_style, LV_OPA_COVER);
-        lv_style_set_radius(&status_style, 12);
-        lv_style_set_border_width(&status_style, 0);
-        lv_obj_add_style(status_indicator, &status_style, 0);
+        lv_obj_add_style(status_indicator, ui_styles_get_status_ok(), 0);
         
         lv_obj_t *status_text = lv_label_create(status_indicator);
         lv_label_set_text(status_text, "OK");
@@ -336,12 +329,6 @@ static lv_obj_t* create_alerts_screen(lv_obj_t *parent)
         {"INFO", "Maintenance programmée demain", "Nettoyage système filtration"}
     };
     
-    lv_color_t alert_colors[] = {
-        COLOR_ACCENT_ORANGE,
-        COLOR_ACCENT_ORANGE, 
-        COLOR_ACCENT_BLUE
-    };
-    
     for (int i = 0; i < 3; i++) {
         lv_obj_t *alert_card = lv_obj_create(screen);
         lv_obj_remove_style_all(alert_card);
@@ -354,13 +341,17 @@ static lv_obj_t* create_alerts_screen(lv_obj_t *parent)
         lv_obj_set_size(level_indicator, 6, 60);
         lv_obj_set_pos(level_indicator, 8, 10);
         
-        static lv_style_t level_style;
-        lv_style_init(&level_style);
-        lv_style_set_bg_color(&level_style, alert_colors[i]);
-        lv_style_set_bg_opa(&level_style, LV_OPA_COVER);
-        lv_style_set_radius(&level_style, 3);
-        lv_style_set_border_width(&level_style, 0);
-        lv_obj_add_style(level_indicator, &level_style, 0);
+        switch (i) {
+            case 0:
+                lv_obj_add_style(level_indicator, ui_styles_get_alert_level_critical(), 0);
+                break;
+            case 1:
+                lv_obj_add_style(level_indicator, ui_styles_get_alert_level_warning(), 0);
+                break;
+            default:
+                lv_obj_add_style(level_indicator, ui_styles_get_alert_level_info(), 0);
+                break;
+        }
         
         // Niveau d'alerte
         lv_obj_t *level_label = lv_label_create(alert_card);

--- a/main/ui/ui_sidebar.c
+++ b/main/ui/ui_sidebar.c
@@ -111,14 +111,7 @@ static esp_err_t create_menu_item(lv_obj_t *parent, int index, int y_pos)
     lv_obj_set_size(item->indicator, 8, 8);
     lv_obj_set_pos(item->indicator, SIDEBAR_WIDTH - 40, 21);
     lv_obj_add_flag(item->indicator, LV_OBJ_FLAG_HIDDEN); // Caché par défaut
-    
-    static lv_style_t indicator_style;
-    lv_style_init(&indicator_style);
-    lv_style_set_bg_color(&indicator_style, COLOR_ACCENT_ORANGE);
-    lv_style_set_bg_opa(&indicator_style, LV_OPA_COVER);
-    lv_style_set_radius(&indicator_style, 4);
-    lv_style_set_border_width(&indicator_style, 0);
-    lv_obj_add_style(item->indicator, &indicator_style, 0);
+    lv_obj_add_style(item->indicator, ui_styles_get_nav_indicator(), 0);
     
     // Configuration de l'élément
     item->screen_type = menu_data[index].screen;

--- a/main/ui/ui_styles.c
+++ b/main/ui/ui_styles.c
@@ -35,6 +35,13 @@ static lv_style_t style_nav_normal;
 static lv_style_t style_nav_active;
 static lv_style_t style_nav_hover;
 
+// Styles pour les indicateurs et états
+static lv_style_t style_nav_indicator;
+static lv_style_t style_status_ok;
+static lv_style_t style_alert_level_critical;
+static lv_style_t style_alert_level_warning;
+static lv_style_t style_alert_level_info;
+
 /**
  * @brief Initialise les styles des conteneurs principaux
  */
@@ -213,6 +220,45 @@ static void init_navigation_styles(void)
     lv_style_set_border_width(&style_nav_hover, 0);
 }
 
+/**
+ * @brief Initialise les styles d'indicateurs et d'états
+ */
+static void init_indicator_styles(void)
+{
+    // Indicateur de notification pour la sidebar
+    lv_style_init(&style_nav_indicator);
+    lv_style_set_bg_color(&style_nav_indicator, COLOR_ACCENT_ORANGE);
+    lv_style_set_bg_opa(&style_nav_indicator, LV_OPA_COVER);
+    lv_style_set_radius(&style_nav_indicator, 4);
+    lv_style_set_border_width(&style_nav_indicator, 0);
+
+    // Indicateur de statut OK
+    lv_style_init(&style_status_ok);
+    lv_style_set_bg_color(&style_status_ok, COLOR_ACCENT_GREEN);
+    lv_style_set_bg_opa(&style_status_ok, LV_OPA_COVER);
+    lv_style_set_radius(&style_status_ok, 12);
+    lv_style_set_border_width(&style_status_ok, 0);
+
+    // Niveaux d'alerte
+    lv_style_init(&style_alert_level_critical);
+    lv_style_set_bg_color(&style_alert_level_critical, COLOR_ACCENT_ORANGE);
+    lv_style_set_bg_opa(&style_alert_level_critical, LV_OPA_COVER);
+    lv_style_set_radius(&style_alert_level_critical, 3);
+    lv_style_set_border_width(&style_alert_level_critical, 0);
+
+    lv_style_init(&style_alert_level_warning);
+    lv_style_set_bg_color(&style_alert_level_warning, COLOR_ACCENT_ORANGE);
+    lv_style_set_bg_opa(&style_alert_level_warning, LV_OPA_COVER);
+    lv_style_set_radius(&style_alert_level_warning, 3);
+    lv_style_set_border_width(&style_alert_level_warning, 0);
+
+    lv_style_init(&style_alert_level_info);
+    lv_style_set_bg_color(&style_alert_level_info, COLOR_ACCENT_BLUE);
+    lv_style_set_bg_opa(&style_alert_level_info, LV_OPA_COVER);
+    lv_style_set_radius(&style_alert_level_info, 3);
+    lv_style_set_border_width(&style_alert_level_info, 0);
+}
+
 esp_err_t ui_styles_init(void)
 {
     ESP_LOGI(TAG, "Initialisation des styles NovaReptileElevage");
@@ -222,6 +268,7 @@ esp_err_t ui_styles_init(void)
     init_card_styles();
     init_text_styles();
     init_navigation_styles();
+    init_indicator_styles();
     
     ESP_LOGI(TAG, "Styles initialisés avec succès");
     return ESP_OK;
@@ -254,3 +301,10 @@ lv_style_t* ui_styles_get_text_small(void) { return &style_text_small; }
 lv_style_t* ui_styles_get_nav_item_normal(void) { return &style_nav_normal; }
 lv_style_t* ui_styles_get_nav_item_active(void) { return &style_nav_active; }
 lv_style_t* ui_styles_get_nav_item_hover(void) { return &style_nav_hover; }
+
+// Getters pour les styles d'indicateurs et d'états
+lv_style_t* ui_styles_get_nav_indicator(void) { return &style_nav_indicator; }
+lv_style_t* ui_styles_get_status_ok(void) { return &style_status_ok; }
+lv_style_t* ui_styles_get_alert_level_critical(void) { return &style_alert_level_critical; }
+lv_style_t* ui_styles_get_alert_level_warning(void) { return &style_alert_level_warning; }
+lv_style_t* ui_styles_get_alert_level_info(void) { return &style_alert_level_info; }

--- a/main/ui/ui_styles.h
+++ b/main/ui/ui_styles.h
@@ -67,6 +67,13 @@ lv_style_t* ui_styles_get_nav_item_normal(void);
 lv_style_t* ui_styles_get_nav_item_active(void);
 lv_style_t* ui_styles_get_nav_item_hover(void);
 
+// Getters pour les styles d'indicateurs
+lv_style_t* ui_styles_get_nav_indicator(void);
+lv_style_t* ui_styles_get_status_ok(void);
+lv_style_t* ui_styles_get_alert_level_critical(void);
+lv_style_t* ui_styles_get_alert_level_warning(void);
+lv_style_t* ui_styles_get_alert_level_info(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- centralize sidebar indicator, status and alert level styles in ui_styles.c with dedicated getters
- replace local `lv_style_init` blocks in sidebar and content creation with `lv_obj_add_style(..., ui_styles_get_*(), 0)`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b838cebd448323b60100a255869269