### PR TITLE
docs: corriger chemin lv_conf et partage LV_CONF_INCLUDE_SIMPLE

### DIFF
--- a/Guide_MenuConfig_NovaReptileElevage.md
+++ b/Guide_MenuConfig_NovaReptileElevage.md
@@ -317,7 +317,8 @@ Power Management → Enable dynamic frequency scaling (DFS) : [*] (activé)
 
 ### 17. Vérification lv_conf.h
 
-Assurez-vous que `main/lv_conf.h` contient :
+Le fichier `components/lvgl/lv_conf.h` est partagé dans tout le projet via `LV_CONF_INCLUDE_SIMPLE`.
+Assurez-vous que `components/lvgl/lv_conf.h` contient :
 
 ```c
 // Optimisations ESP32-S3

--- a/README.md
+++ b/README.md
@@ -42,9 +42,12 @@ Interface utilisateur complète pour système d'élevage de reptiles utilisant L
 
 ### Structure des fichiers
 ```
+components/
+└── lvgl/
+    ├── lv_conf.h         # Configuration LVGL partagée
+    └── ...               # Bibliothèque LVGL
 main/
-├── main.c                 # Point d'entrée principal
-├── lv_conf.h             # Configuration LVGL
+├── main.c                # Point d'entrée principal
 ├── ui/                   # Interface utilisateur
 │   ├── ui_main.c/.h      # Gestionnaire principal UI
 │   ├── ui_header.c/.h    # Barre de titre
@@ -56,6 +59,8 @@ main/
     ├── display_driver.c/.h  # ST7262 (800x480)
     └── touch_driver.c/.h    # GT911 (tactile)
 ```
+
+Le fichier `lv_conf.h` est placé dans `components/lvgl/` et, grâce à la définition `LV_CONF_INCLUDE_SIMPLE`, il est accessible à l'ensemble du projet.
 
 ### Écrans disponibles
 1. **Tableau de bord** - Vue d'ensemble du système
@@ -113,7 +118,7 @@ idf.py -p /dev/ttyUSB0 flash monitor
 ```
 
 ### Configuration LVGL
-Le fichier `lv_conf.h` est configuré pour:
+Le fichier `components/lvgl/lv_conf.h` est configuré pour:
 - Profondeur couleur 16-bit (RGB565)
 - Buffer mémoire 64KB
 - Widgets essentiels activés

--- a/components/README.md
+++ b/components/README.md
@@ -41,6 +41,7 @@ components/
 
 ## Configuration
 
-- Le fichier de configuration LVGL se trouve dans `main/lv_conf.h`
+- Le fichier de configuration LVGL se trouve dans `components/lvgl/lv_conf.h`
+- Ce fichier est partagé dans tout le projet grâce à la macro `LV_CONF_INCLUDE_SIMPLE`
 - Les paramètres sont optimisés pour ESP32-S3 avec écran 800x480
 - Support tactile GT911 activé

--- a/components/lvgl/README.md
+++ b/components/lvgl/README.md
@@ -22,7 +22,8 @@ Pour installer LVGL dans ce composant :
 
 ## Configuration
 
-Le fichier `lv_conf.h` se trouve dans `main/lv_conf.h` et est configuré pour :
+Le fichier `lv_conf.h` se trouve dans `components/lvgl/lv_conf.h` et est configuré pour :
+Grâce à la définition `LV_CONF_INCLUDE_SIMPLE`, ce fichier unique est accessible aux sources du composant et de l'application.
 - Écran 800x480 16-bit (RGB565)
 - Tactile GT911
 - Widgets essentiels activés


### PR DESCRIPTION
## Summary
- documenter le placement de `components/lvgl/lv_conf.h`
- préciser que la configuration LVGL est partagée via `LV_CONF_INCLUDE_SIMPLE`

## Testing
- `cmake -S . -B build` *(échec : /tools/cmake/project.cmake introuvable)*
- `idf.py --version` *(commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68b848d3cb288323aa5fcf38198947f9