### PR TITLE
Rename reset pin macros for display and touch drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ Le fichier `lv_conf.h` est placé dans `components/lvgl/` et, grâce à la défi
 #define PIN_CLK     12
 #define PIN_CS      10
 #define PIN_DC      14
-#define PIN_RST     21
+#define DISPLAY_PIN_RST 21
 #define PIN_BCKL    2
 
 // Tactile GT911
 #define PIN_SDA     8
 #define PIN_SCL     9
 #define PIN_INT     18
-#define PIN_RST     17
+#define TOUCH_PIN_RST 17
 ```
 
 ### Paramètres SPI/I2C

--- a/main/drivers/display_driver.c
+++ b/main/drivers/display_driver.c
@@ -22,7 +22,7 @@ static const char *TAG = "Display_Driver";
 #define PIN_CLK         12
 #define PIN_CS          10
 #define PIN_DC          14
-#define PIN_RST         21
+#define DISPLAY_PIN_RST 21
 #define PIN_BCKL        2
 
 // Configuration SPI
@@ -93,9 +93,9 @@ static void st7262_init(void)
     ESP_LOGI(TAG, "Initialisation du contrôleur ST7262");
     
     // Reset du contrôleur
-    gpio_set_level(PIN_RST, 0);
+    gpio_set_level(DISPLAY_PIN_RST, 0);
     vTaskDelay(pdMS_TO_TICKS(100));
-    gpio_set_level(PIN_RST, 1);
+    gpio_set_level(DISPLAY_PIN_RST, 1);
     vTaskDelay(pdMS_TO_TICKS(100));
     
     // Séquence d'initialisation ST7262
@@ -207,7 +207,7 @@ esp_err_t display_driver_init(void)
     
     // Configuration des GPIO
     gpio_config_t io_conf = {
-        .pin_bit_mask = (1ULL << PIN_DC) | (1ULL << PIN_RST),
+        .pin_bit_mask = (1ULL << PIN_DC) | (1ULL << DISPLAY_PIN_RST),
         .mode = GPIO_MODE_OUTPUT,
         .pull_up_en = GPIO_PULLUP_DISABLE,
         .pull_down_en = GPIO_PULLDOWN_DISABLE,

--- a/main/drivers/touch_driver.c
+++ b/main/drivers/touch_driver.c
@@ -17,7 +17,7 @@ static const char *TAG = "Touch_Driver";
 #define PIN_SDA 8
 #define PIN_SCL 9
 #define PIN_INT 18
-#define PIN_RST 17
+#define TOUCH_PIN_RST 17
 
 // Configuration I2C
 #define I2C_PORT I2C_NUM_0
@@ -100,9 +100,9 @@ static esp_err_t gt911_init(void) {
   ESP_LOGI(TAG, "Initialisation du contrôleur GT911");
 
   // Reset du contrôleur
-  gpio_set_level(PIN_RST, 0);
+  gpio_set_level(TOUCH_PIN_RST, 0);
   vTaskDelay(pdMS_TO_TICKS(10));
-  gpio_set_level(PIN_RST, 1);
+  gpio_set_level(TOUCH_PIN_RST, 1);
   vTaskDelay(pdMS_TO_TICKS(100));
 
   // Lecture de l'ID du contrôleur
@@ -221,7 +221,7 @@ esp_err_t touch_driver_init(void) {
 
   // Configuration des GPIO
   gpio_config_t io_conf = {
-      .pin_bit_mask = (1ULL << PIN_RST) | (1ULL << PIN_INT),
+      .pin_bit_mask = (1ULL << TOUCH_PIN_RST) | (1ULL << PIN_INT),
       .mode = GPIO_MODE_OUTPUT,
       .pull_up_en = GPIO_PULLUP_DISABLE,
       .pull_down_en = GPIO_PULLDOWN_DISABLE,
@@ -306,7 +306,7 @@ void touch_set_enable(bool enable) {
      */
     gpio_set_direction(PIN_INT, GPIO_MODE_OUTPUT);
     gpio_set_level(PIN_INT, 0);
-    gpio_set_level(PIN_RST, 1);
+    gpio_set_level(TOUCH_PIN_RST, 1);
     vTaskDelay(pdMS_TO_TICKS(50));
     gpio_set_direction(PIN_INT, GPIO_MODE_INPUT);
   } else {
@@ -319,7 +319,7 @@ void touch_set_enable(bool enable) {
      */
     gpio_set_direction(PIN_INT, GPIO_MODE_OUTPUT);
     gpio_set_level(PIN_INT, 0);
-    gpio_set_level(PIN_RST, 0);
+    gpio_set_level(TOUCH_PIN_RST, 0);
   }
 }
 


### PR DESCRIPTION
## Summary
- rename display reset pin macro to `DISPLAY_PIN_RST`
- rename touch reset pin macro to `TOUCH_PIN_RST`
- update README and driver sources accordingly

## Testing
- `cmake -S . -B build` *(fails: include could not find requested file: /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b2b45908323b0c5ac3d8c1fb169