### PR TITLE
feat(ui): add profile menu and quick settings

### DIFF
--- a/main/ui/ui_header.h
+++ b/main/ui/ui_header.h
@@ -39,6 +39,18 @@ void ui_header_set_connection_status(bool connected);
  */
 void ui_header_set_time(const char *time_str);
 
+/**
+ * @brief Ouvre le menu profil
+ * @return esp_err_t Code d'erreur
+ */
+esp_err_t ui_header_open_profile_menu(void);
+
+/**
+ * @brief Ouvre le panneau de réglages rapides
+ * @return esp_err_t Code d'erreur
+ */
+esp_err_t ui_header_open_quick_settings(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary
- implement profile menu popup and quick settings panel
- expose header APIs for profile and quick settings
- add extensive debug logging throughout header

## Testing
- `idf.py build` *(fails: command not found)*
- `cmake -S . -B build` *(fails: include could not find requested file /tools/cmake/project.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b84feb64588323b56aa7baf809760a