### PR TITLE
Update icon descriptors for LVGL 9

### DIFF
--- a/main/ui/ui_icons.c
+++ b/main/ui/ui_icons.c
@@ -24,10 +24,10 @@ static const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST uint8_t ui_img_prof
     0x00, 0x00
 };
 
-const lv_img_dsc_t ui_img_profile = {
-    .header.cf = LV_IMG_CF_ALPHA_1BIT,
-    .header.always_zero = 0,
-    .header.reserved = 0,
+const lv_image_dsc_t ui_img_profile = {
+    .header.magic = LV_IMAGE_HEADER_MAGIC,
+    .header.cf = LV_COLOR_FORMAT_A1,
+    .header.flags = 0,
     .header.w = 16,
     .header.h = 16,
     .data_size = sizeof(ui_img_profile_map),

--- a/main/ui/ui_icons.h
+++ b/main/ui/ui_icons.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-extern const lv_img_dsc_t ui_img_profile;
+extern const lv_image_dsc_t ui_img_profile;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- migrate icon descriptor to `lv_image_dsc_t` and new header fields
- replace deprecated color format constant with `LV_COLOR_FORMAT_A1`

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b864d0a2a88323a07b50ea1dd31ebc