### PR TITLE
feat: configure I2C bus clock source and pullups

### DIFF
--- a/main/drivers/touch_driver.c
+++ b/main/drivers/touch_driver.c
@@ -264,7 +264,15 @@ esp_err_t touch_driver_init(void) {
       .i2c_port = I2C_PORT,
       .sda_io_num = PIN_SDA,
       .scl_io_num = PIN_SCL,
+      .clk_source = I2C_CLK_SRC_DEFAULT, // ou I2C_CLK_SRC_PLL_F80 selon la carte
+      .flags = {
+          .enable_internal_pullup = true,
+      },
   };
+
+  // Activation explicite des pull-ups si non gérés par l'API
+  gpio_pullup_en(PIN_SDA);
+  gpio_pullup_en(PIN_SCL);
 
   ret = i2c_new_master_bus(&bus_conf, &i2c_bus);
   if (ret != ESP_OK) {


### PR DESCRIPTION
## Summary
- configure I2C bus with explicit clock source and internal pull-ups
- ensure SDA/SCL pull-ups enabled when API lacks built-in support

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b95444fc108323887bb74888e63c2e