### PR TITLE
Set default LVGL display and validate active screen

### DIFF
--- a/main/drivers/display_driver.c
+++ b/main/drivers/display_driver.c
@@ -80,6 +80,7 @@ esp_err_t display_driver_init(void)
         return ESP_ERR_NO_MEM;
     }
     display = lv_display_create(DISPLAY_WIDTH, DISPLAY_HEIGHT);
+    lv_display_set_default(display);
     lv_display_set_flush_cb(display, display_flush_cb);
     lv_display_set_buffers(display, buf1, buf2,
                            DISPLAY_BUF_SIZE * sizeof(lv_color_t),

--- a/main/ui/ui_main.c
+++ b/main/ui/ui_main.c
@@ -124,7 +124,14 @@ esp_err_t ui_main_init(void)
     
     // Chargement de l'écran principal
     lv_scr_load(g_nova_ui.main_screen);
-    
+
+    // Vérification que l'écran actif est valide
+    lv_obj_t *active = lv_scr_act();
+    if (!active) {
+        ESP_LOGE(TAG, "lv_scr_act() renvoie NULL après le premier chargement d'écran");
+        return ESP_FAIL;
+    }
+
     // Affichage initial du tableau de bord
     ui_main_set_screen(SCREEN_DASHBOARD);
     


### PR DESCRIPTION
## Summary
- ensure `lv_display_set_default` is called after creating display
- verify `lv_scr_act()` returns a valid screen on initial load

## Testing
- `idf.py --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b96101f0a48323a1512a7d1bdd080c