### PR TITLE
refactor: separate ST7262 SPI pins from RGB signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ Le fichier `lv_conf.h` est placé dans `components/lvgl/` et, grâce à la défi
 ### Broches ESP32-S3 (Waveshare 7")
 ```c
 // Affichage ST7262
-#define PIN_MOSI    11
-#define PIN_MISO    13
-#define PIN_CLK     12
-#define PIN_CS      10
-#define PIN_DC      14
+#define PIN_MOSI       11
+#define PIN_MISO       -1   // non utilisé
+#define PIN_CLK        6
+#define PIN_CS         12
+#define PIN_DC         4
 #define DISPLAY_PIN_RST 21
-#define PIN_BCKL    2
+#define PIN_BCKL       2
 
 // Tactile GT911
 #define PIN_SDA     8
@@ -89,6 +89,8 @@ Le fichier `lv_conf.h` est placé dans `components/lvgl/` et, grâce à la défi
 #define PIN_INT     18
 #define TOUCH_PIN_RST 17
 ```
+
+Les broches MOSI et CS ont été déplacées respectivement sur GPIO11 et GPIO12 afin d'éliminer tout conflit avec les signaux RGB (PCLK en GPIO7 et DE en GPIO5).
 
 ### Paramètres SPI/I2C
 - **SPI**: 40MHz, Mode 0, DMA activé

--- a/components/st7262_rgb/st7262_rgb.c
+++ b/components/st7262_rgb/st7262_rgb.c
@@ -31,8 +31,8 @@ static const int lcd_data_gpios[16] = {
 // SPI interface for ST7262 command configuration
 #define LCD_CMD_SPI_HOST SPI2_HOST
 #define LCD_CMD_SCLK_GPIO  6
-#define LCD_CMD_MOSI_GPIO  7
-#define LCD_CMD_CS_GPIO    5
+#define LCD_CMD_MOSI_GPIO  11
+#define LCD_CMD_CS_GPIO    12
 #define LCD_CMD_DC_GPIO    4
 
 typedef struct {


### PR DESCRIPTION
## Summary
- route MOSI to GPIO11 and CS to GPIO12 for ST7262 command SPI
- document updated wiring to prevent conflicts with RGB interface

## Testing
- `idf.py build` *(fails: command not found)*
- `python - <<'PY' ...` (verifies no pin overlap)

------
https://chatgpt.com/codex/tasks/task_e_68b97b6d34f48323b29c1650388e5e50