### PR TITLE
Handle display flush draw errors

### DIFF
--- a/main/drivers/display_driver.c
+++ b/main/drivers/display_driver.c
@@ -27,9 +27,12 @@ static void display_flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t 
     int64_t start = esp_timer_get_time();
     ESP_LOGD(TAG, "flush start (%d,%d)->(%d,%d) size %dx%d",
              area->x1, area->y1, area->x2, area->y2, w, h);
-    esp_lcd_panel_draw_bitmap(panel_handle, area->x1, area->y1,
-                              area->x2 + 1, area->y2 + 1, px_map);
-    lv_display_flush_ready(disp);
+    if (esp_lcd_panel_draw_bitmap(panel_handle, area->x1, area->y1,
+                                  area->x2 + 1, area->y2 + 1, px_map) == ESP_OK) {
+        lv_display_flush_ready(disp);
+    } else {
+        ESP_LOGE(TAG, "esp_lcd_panel_draw_bitmap failed");
+    }
     int64_t end = esp_timer_get_time();
     ESP_LOGD(TAG, "flush end (%d,%d)->(%d,%d) size %dx%d, %lld us",
              area->x1, area->y1, area->x2, area->y2, w, h,


### PR DESCRIPTION
## Summary
- add error check around `esp_lcd_panel_draw_bitmap` in display flush callback

## Testing
- `gcc /tmp/test_display_flush_cb.c -o /tmp/test_display_flush_cb && /tmp/test_display_flush_cb`
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b987cc228c8323a4924e37fe38ef99