### PR TITLE
feat: enhance flash script options

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ idf.py set-target esp32s3
 idf.py menuconfig
 
 # Compilation et flash
-./scripts/build_flash.sh /dev/ttyUSB0
+./scripts/build_flash.sh /dev/ttyUSB0 [--baud 921600] [--erase]
+# --baud : définit la vitesse de flash
+# --erase : efface la mémoire flash avant programmation
 # ou manuellement
 idf.py build
 idf.py -p /dev/ttyUSB0 flash

--- a/scripts/build_flash.sh
+++ b/scripts/build_flash.sh
@@ -1,8 +1,59 @@
 #!/bin/bash
 set -e
+
+usage() {
+  echo "Usage: $0 <PORT> [--baud <BAUD>] [--erase]"
+}
+
 if [ -z "$1" ]; then
-  echo "Usage: $0 <PORT>"
+  usage
   exit 1
 fi
+
+PORT="$1"
+shift
+
+BAUD=""
+ERASE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baud)
+      if [[ -n "$2" && "$2" != --* ]]; then
+        BAUD="$2"
+        shift 2
+      else
+        echo "Error: --baud requires an argument"
+        usage
+        exit 1
+      fi
+      ;;
+    --erase)
+      ERASE=1
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [ ! -f sdkconfig ] || ! grep -q '^CONFIG_SPIRAM=y' sdkconfig; then
+  echo "Erreur: PSRAM non activée dans sdkconfig (CONFIG_SPIRAM)."
+  exit 1
+fi
+
 idf.py build
-idf.py -p "$1" flash
+
+FLASH_ARGS=(-p "$PORT")
+if [ -n "$BAUD" ]; then
+  FLASH_ARGS+=(-b "$BAUD")
+fi
+
+if [ "$ERASE" -eq 1 ]; then
+  idf.py "${FLASH_ARGS[@]}" erase_flash
+fi
+
+idf.py "${FLASH_ARGS[@]}" flash


### PR DESCRIPTION
## Summary
- enforce PSRAM activation before building
- allow --baud and --erase options in build_flash script
- document optional script parameters in README

## Testing
- `bash -n scripts/build_flash.sh`
- `./scripts/build_flash.sh /dev/null --baud 115200 --erase` *(fails: idf.py: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9889df4c48323afc9d82667e65952