### PR TITLE
vérifie PSRAM avant init LVGL

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ Les broches MOSI et CS ont été déplacées respectivement sur GPIO11 et GPIO12
 - PSRAM activée (support SPIRAM obligatoire pour le frame buffer)
 - Carte Waveshare ESP32-S3 Touch LCD 7"
 
+#### Démarrage sans PSRAM
+
+Lors de l'initialisation, le firmware vérifie la présence de la PSRAM via `esp_psram_init()` puis `esp_psram_get_chip_size()`. Si aucune PSRAM n'est détectée (taille nulle), l'initialisation est interrompue et l'erreur suivante est journalisée :
+
+```
+ESP_LOGE(TAG, "Aucune PSRAM détectée - initialisation annulée");
+```
+
+Dans ce cas, `nova_reptile_init()` renvoie `ESP_ERR_NO_MEM` avant toute configuration de LVGL. Activez la PSRAM dans `menuconfig` (**Component config → ESP PSRAM**) ou utilisez une carte dotée de SPIRAM pour exécuter l'application.
+
 ### Étapes de compilation
 ```bash
 # Clonage du projet

--- a/main/main.c
+++ b/main/main.c
@@ -17,6 +17,7 @@
 #include "nvs_flash.h"
 #include "esp_random.h"
 #include "esp_timer.h"
+#include "esp_psram.h"
 
 #include "lvgl.h"
 #include "ui_main.h"
@@ -69,9 +70,22 @@ static esp_err_t nova_reptile_init(void)
         ret = nvs_flash_init();
     }
     ESP_ERROR_CHECK(ret);
-    
+
+    // Initialisation et vérification de la PSRAM
+    ret = esp_psram_init();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Erreur initialisation PSRAM: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    size_t psram_size = esp_psram_get_chip_size();
+    if (psram_size == 0) {
+        ESP_LOGE(TAG, "Aucune PSRAM détectée - initialisation annulée");
+        return ESP_ERR_NO_MEM;
+    }
+
     // Initialisation de LVGL
-    ESP_LOGI(TAG, "Initialisation LVGL v%d.%d.%d", 
+    ESP_LOGI(TAG, "Initialisation LVGL v%d.%d.%d",
              lv_version_major(), lv_version_minor(), lv_version_patch());
     lv_init();
     


### PR DESCRIPTION
## Summary
- initialise et valide la PSRAM avant d'initialiser LVGL, renvoyant ESP_ERR_NO_MEM si absente
- documente le comportement sans PSRAM dans le README pour guider l'utilisateur

## Testing
- `idf.py build` *(failed: command not found)*
- `pip install esp-idf` *(failed: no matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68b98e8a919c8323b46ca171357cbeba