### PR TITLE
feat: add global deinit for lvgl tick timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ libérées dans l'ordre inverse suivant :
 
 Cette séquence garantit une désinitialisation propre sans fuite de ressources.
 
+### Déinitialisation globale
+
+Pour un arrêt contrôlé ou avant tout appel à `esp_restart()`,
+`nova_reptile_deinit()` doit être invoquée. Cette fonction arrête et supprime
+le timer `lvgl_tick_timer`, puis libère successivement les styles UI, le driver
+tactile, le driver d'affichage et enfin le cœur LVGL.
+
 ### Étapes de compilation
 ```bash
 # Clonage du projet

--- a/main/main.c
+++ b/main/main.c
@@ -129,6 +129,28 @@ static esp_err_t nova_reptile_init(void)
 }
 
 /**
+ * @brief Déinitialisation globale du système NovaReptileElevage
+ *
+ * Libère l'ensemble des sous-systèmes initialisés par nova_reptile_init()
+ * et arrête le timer haute résolution utilisé par LVGL.
+ */
+static void nova_reptile_deinit(void)
+{
+    if (lvgl_tick_timer) {
+        ESP_ERROR_CHECK(esp_timer_stop(lvgl_tick_timer));
+        ESP_ERROR_CHECK(esp_timer_delete(lvgl_tick_timer));
+        lvgl_tick_timer = NULL;
+    }
+
+    ui_styles_deinit();
+    touch_driver_deinit();
+    display_driver_deinit();
+    lv_deinit();
+
+    ESP_LOGI(TAG, "Système NovaReptileElevage déinitialisé");
+}
+
+/**
  * @brief Fonction principale de l'application
  */
 void app_main(void)
@@ -164,6 +186,7 @@ void app_main(void)
 
     if (task_ret != pdPASS) {
         ESP_LOGE(TAG, "Échec création tâche LVGL: %ld", task_ret);
+        nova_reptile_deinit();
         esp_restart();
     }
     


### PR DESCRIPTION
## Summary
- add nova_reptile_deinit() to stop and delete lvgl_tick_timer and release UI, touch, display, and LVGL subsystems
- call nova_reptile_deinit() before esp_restart on task creation failure
- document global deinitialization procedure in README

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9a691ba88323832ccacd029f649b