### PR TITLE
Move flush-ready call outside draw bitmap check

### DIFF
--- a/main/drivers/display_driver.c
+++ b/main/drivers/display_driver.c
@@ -29,10 +29,11 @@ static void display_flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t 
              area->x1, area->y1, area->x2, area->y2, w, h);
     if (esp_lcd_panel_draw_bitmap(panel_handle, area->x1, area->y1,
                                   area->x2 + 1, area->y2 + 1, px_map) == ESP_OK) {
-        lv_display_flush_ready(disp);
+        /* nothing */
     } else {
         ESP_LOGE(TAG, "esp_lcd_panel_draw_bitmap failed");
     }
+    lv_display_flush_ready(disp);
     int64_t end = esp_timer_get_time();
     ESP_LOGD(TAG, "flush end (%d,%d)->(%d,%d) size %dx%d, %lld us",
              area->x1, area->y1, area->x2, area->y2, w, h,


### PR DESCRIPTION
## Summary
- ensure display flush ready is always called after esp_lcd_panel_draw_bitmap

## Testing
- `idf.py --version` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9b487f408323b4ad69392578cc5c