### PR TITLE
feat(ui): add header deinit and guard style init

### DIFF
--- a/main/ui/ui_header.c
+++ b/main/ui/ui_header.c
@@ -23,9 +23,14 @@ static lv_obj_t *quick_settings_panel;
 
 static lv_style_t style_connected;
 static lv_style_t style_disconnected;
+static bool header_styles_initialized = false;
 
 static void init_header_styles(void)
 {
+    if (header_styles_initialized) {
+        return;
+    }
+
     lv_style_init(&style_connected);
     lv_style_set_bg_color(&style_connected, COLOR_ACCENT_GREEN);
     lv_style_set_bg_opa(&style_connected, LV_OPA_COVER);
@@ -37,6 +42,8 @@ static void init_header_styles(void)
     lv_style_set_bg_opa(&style_disconnected, LV_OPA_COVER);
     lv_style_set_radius(&style_disconnected, 6);
     lv_style_set_border_width(&style_disconnected, 0);
+
+    header_styles_initialized = true;
 }
 
 /**
@@ -299,4 +306,11 @@ void ui_header_set_time(const char *time_str)
         lv_label_set_text(header_time, time_str);
         ESP_LOGI(TAG, "Heure mise à jour: %s", time_str);
     }
+}
+
+void ui_header_deinit(void)
+{
+    lv_style_reset(&style_connected);
+    lv_style_reset(&style_disconnected);
+    header_styles_initialized = false;
 }

--- a/main/ui/ui_header.h
+++ b/main/ui/ui_header.h
@@ -22,6 +22,11 @@ extern "C" {
 esp_err_t ui_header_init(lv_obj_t *parent);
 
 /**
+ * @brief Libère les ressources du header
+ */
+void ui_header_deinit(void);
+
+/**
  * @brief Met à jour le titre affiché
  * @param title Nouveau titre à afficher
  */


### PR DESCRIPTION
## Summary
- add ui_header_deinit to reset static styles
- ensure header styles initialized only once via flag

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bab2a40e4883239201459aaeaef5e4