### PR TITLE
feat(ui): add critical alert red style

### DIFF
--- a/main/ui/ui_styles.c
+++ b/main/ui/ui_styles.c
@@ -242,7 +242,7 @@ static void init_indicator_styles(void)
 
     // Niveaux d'alerte
     lv_style_init(&style_alert_level_critical);
-    lv_style_set_bg_color(&style_alert_level_critical, COLOR_ACCENT_ORANGE);
+    lv_style_set_bg_color(&style_alert_level_critical, COLOR_ACCENT_RED);
     lv_style_set_bg_opa(&style_alert_level_critical, LV_OPA_COVER);
     lv_style_set_radius(&style_alert_level_critical, 3);
     lv_style_set_border_width(&style_alert_level_critical, 0);

--- a/main/ui/ui_styles.h
+++ b/main/ui/ui_styles.h
@@ -21,6 +21,7 @@ extern "C" {
 #define COLOR_ACCENT_BLUE    lv_color_hex(0x4A90E2)  // Bleu doux
 #define COLOR_ACCENT_GREEN   lv_color_hex(0x7ED321)  // Vert nature
 #define COLOR_ACCENT_ORANGE  lv_color_hex(0xF5A623)  // Orange alertes
+#define COLOR_ACCENT_RED     lv_color_hex(0xD32F2F)  // Rouge critique
 #define COLOR_TEXT_DARK      lv_color_hex(0x2C3E50)  // Gris anthracite
 #define COLOR_TEXT_MEDIUM    lv_color_hex(0x5D6D7E)  // Gris moyen
 #define COLOR_TEXT_LIGHT     lv_color_hex(0x85929E)  // Gris clair


### PR DESCRIPTION
## Summary
- add red accent color constant for critical alerts
- use new red accent in critical alert style

## Testing
- `idf.py build` *(fails: command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68babb475b9483239ae033065f0d70cc