### PR TITLE
Validate st7262 RGB panel handle pointers

### DIFF
--- a/components/st7262_rgb/st7262_rgb.c
+++ b/components/st7262_rgb/st7262_rgb.c
@@ -51,6 +51,10 @@ static const st7262_init_cmd_t st7262_init_cmds[] = {
 };
 
 esp_err_t st7262_rgb_new_panel(esp_lcd_panel_handle_t *ret_panel) {
+  if (!ret_panel) {
+    return ESP_ERR_INVALID_ARG;
+  }
+
   esp_err_t ret;
   esp_lcd_panel_handle_t panel = NULL;
 
@@ -173,5 +177,9 @@ esp_err_t st7262_rgb_new_panel(esp_lcd_panel_handle_t *ret_panel) {
   ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel, true));
 
   *ret_panel = panel;
+  if (*ret_panel == NULL) {
+    return ESP_FAIL;
+  }
+
   return ESP_OK;
 }


### PR DESCRIPTION
## Summary
- ensure `st7262_rgb_new_panel` rejects null output pointer
- fail initialization when the created panel handle is null

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68babbd48b5c8323895b692c3a6b697e