### PR TITLE
feat: enforce ESP-IDF target configuration

### DIFF
--- a/scripts/build_flash.sh
+++ b/scripts/build_flash.sh
@@ -3,6 +3,12 @@ set -e
 
 command -v idf.py >/dev/null || { echo "idf.py introuvable"; exit 1; }
 
+# Optionnel: vérifier que la cible esp32s3 est configurée
+if ! idf.py --version 2>/dev/null | grep -q "IDF_TARGET: esp32s3"; then
+  echo "Erreur: cible ESP-IDF esp32s3 non configurée."
+  exit 1
+fi
+
 usage() {
   echo "Usage: $0 <PORT> [--baud <BAUD>] [--erase]"
 }


### PR DESCRIPTION
## Summary
- validate ESP-IDF tool presence and esp32s3 target before build

## Testing
- `bash -n scripts/build_flash.sh && echo syntax-ok`
- `shellcheck scripts/build_flash.sh && echo shellcheck-ok`


------
https://chatgpt.com/codex/tasks/task_e_68bad536e954832399f8d498e656d078