### PR TITLE
chore: add ch422g dependency

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -18,9 +18,10 @@ idf_component_register(
     REQUIRES
         lvgl
         st7262_rgb
-    PRIV_REQUIRES 
+    PRIV_REQUIRES
         nvs_flash
         esp_timer
         esp_psram
         driver
+        ch422g
 )


### PR DESCRIPTION
## Summary
- add ch422g to main component's private requirements

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68badbd189f08323bda20a1e55c1a5d1