### PR TITLE
ch422g: handle I2C timeout

### DIFF
--- a/components/ch422g/ch422g.c
+++ b/components/ch422g/ch422g.c
@@ -20,7 +20,13 @@ static uint8_t s_output_state = 0x00;
 
 static esp_err_t ch422g_write_state(void)
 {
-    return i2c_master_transmit(s_dev, &s_output_state, 1, 1000);
+    esp_err_t err = i2c_master_transmit(s_dev, &s_output_state, 1, 1000);
+    if (err == ESP_ERR_TIMEOUT) {
+        ESP_LOGE(TAG, "i2c_master_transmit timeout");
+    } else if (err != ESP_OK) {
+        ESP_LOGE(TAG, "i2c_master_transmit failed: %s", esp_err_to_name(err));
+    }
+    return err;
 }
 
 esp_err_t ch422g_init(void)


### PR DESCRIPTION
## Summary
- log and propagate I2C timeouts from CH422G write routine

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae6caaf1083238b898573d41b4e7a